### PR TITLE
Fix countdown completion request

### DIFF
--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -50,7 +50,8 @@ export default class extends Controller {
       headers: {
         "Accept": "text/vnd.turbo-stream.html",
         "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
-      }
+      },
+      credentials: "same-origin"
     })
       .then(response => response.text())
       .then(html => Turbo.renderStreamMessage(html))
@@ -63,7 +64,8 @@ export default class extends Controller {
       headers: {
         "Accept": "text/vnd.turbo-stream.html",
         "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
-      }
+      },
+      credentials: "same-origin"
     })
       .then(response => response.text())
       .then(html => Turbo.renderStreamMessage(html))


### PR DESCRIPTION
## Summary
- send cookies when countdown controller posts to Rails

## Testing
- `bin/rails test` *(fails: rbenv: version `3.3.0` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7d15ee0832a825982af4df4045e