### PR TITLE
Fix energy countdown at max

### DIFF
--- a/app/controllers/user_pets_controller.rb
+++ b/app/controllers/user_pets_controller.rb
@@ -103,7 +103,8 @@ class UserPetsController < ApplicationController
     # 2. Deduct energy & handle sleep (cost = 10)
     energy_cost = 10
     begin
-      user_pet.deduct_energy!(energy_cost)
+      user_pet.catch_up_energy!
+      user_pet.spend_energy!(energy_cost)
     rescue UserPet::PetSleepingError, UserPet::NotEnoughEnergyError => e
       flash[:alert] = e.message
       return redirect_to pet_path(user_pet.pet)
@@ -151,6 +152,17 @@ class UserPetsController < ApplicationController
     respond_to do |format|
       format.turbo_stream
       format.html { head :not_acceptable }
+    end
+  end
+
+  # POST /user_pets/:id/energy_tick
+  def energy_tick
+    @user_pet = current_user.user_pets.find(params[:id])
+    @user_pet.catch_up_energy!
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to pet_path(@user_pet.pet) }
     end
   end
 end

--- a/app/javascript/controllers/countdown_controller.js
+++ b/app/javascript/controllers/countdown_controller.js
@@ -13,6 +13,8 @@ export default class extends Controller {
   connect() {
     this.endTime = Date.now() + this.secondsValue * 1000
     this.userExplorationId = this.element.dataset.userExplorationId
+    this.userEggId = this.element.dataset.userEggId
+    this.userPetId = this.element.dataset.userPetId
 
     this.tick()
     this.timer = setInterval(() => this.tick(), 1000)
@@ -40,13 +42,43 @@ export default class extends Controller {
         headers: {
           "Accept": "text/vnd.turbo-stream.html",
           "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
-        }
+        },
+        credentials: "same-origin"
       })
         .then(response => response.text())
         .then(html => Turbo.renderStreamMessage(html))
         .catch(err => console.error("ready_exploration failed:", err))
+    } else if (this.userEggId) {
+      fetch(`/user_eggs/${this.userEggId}/mark_ready`, {
+        method: "POST",
+        headers: {
+          "Accept": "text/vnd.turbo-stream.html",
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+        },
+        credentials: "same-origin"
+      })
+        .then(response => response.text())
+        .then(html => Turbo.renderStreamMessage(html))
+        .catch(err => console.error("ready_egg failed:", err))
+    } else if (this.userPetId) {
+      fetch(`/user_pets/${this.userPetId}/energy_tick`, {
+        method: "POST",
+        headers: {
+          "Accept": "text/vnd.turbo-stream.html",
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+        },
+        credentials: "same-origin"
+      })
+        .then(response => response.text())
+        .then(html => {
+          Turbo.renderStreamMessage(html)
+          // restart timer
+          this.endTime = Date.now() + this.secondsValue * 1000
+          this.timer = setInterval(() => this.tick(), 1000)
+        })
+        .catch(err => console.error("energy_tick failed:", err))
     } else {
-      console.warn("Countdown finished but no exploration ID found.")
+      console.warn("Countdown finished but no target ID found.")
     }
   }
 

--- a/app/views/pets/_energy_display.html.haml
+++ b/app/views/pets/_energy_display.html.haml
@@ -1,0 +1,17 @@
+-# app/views/pets/_energy_display.html.haml
+-# Expects: user_pet
+%div.mb-4
+  %span.font-semibold= "Energy: #{user_pet.energy} / #{UserPet::MAX_ENERGY}"
+  %div.w-full.bg-gray-200.rounded-lg.h-2.mt-1
+    %div.bg-green-500.h-2.rounded-lg{ style: "width: #{user_pet.energy}%;" }
+- if user_pet.energy >= UserPet::MAX_ENERGY
+  %div.mt-1.text-sm.text-gray-600
+    Energy is at Max
+- else
+  %div.mt-1.text-sm.text-gray-600{ data: {
+      controller: 'countdown',
+      countdown_seconds_value: user_pet.seconds_until_next_energy,
+      user_pet_id: user_pet.id
+    } }
+    Next energy in
+    %span{ data: { countdown_target: 'output' } } Loading...

--- a/app/views/pets/show.html.haml
+++ b/app/views/pets/show.html.haml
@@ -9,14 +9,9 @@
       %p.text-lg.font-semibold.text-purple-700
         = "\"#{@user_pet.pet_thought.thought}\""
 
-  -# — REFRESH ENERGY ON PAGE LOAD —#
-  - @user_pet.catch_up_energy!
-
-  -# — ENERGY PROGRESS BAR —#
-  %div.mb-4
-    %span.font-semibold= "Energy: #{@user_pet.energy} / #{UserPet::MAX_ENERGY}"
-    %div.w-full.bg-gray-200.rounded-lg.h-2.mt-1
-      %div.bg-green-500.h-2.rounded-lg{ style: "width: #{@user_pet.energy}%;" }
+  -# — ENERGY DISPLAY + TIMER —#
+  = turbo_frame_tag "pet_energy_#{@user_pet.id}" do
+    = render "energy_display", user_pet: @user_pet
 
   -# — SLEEP COUNTDOWN, IF APPLICABLE —#
   - if @user_pet.asleep_until.present? && Time.current < @user_pet.asleep_until
@@ -27,8 +22,8 @@
   - else
     %p.text-green-600.mb-4= "Pet is awake and ready to play!"
 
-  -# — INTERACTION BUTTONS (COST = 5 ENERGY) —#
-  - cost = 5
+  -# — INTERACTION BUTTONS (COST = 10 ENERGY) —#
+  - cost = 10
   - disabled = (@user_pet.asleep_until.present? && Time.current < @user_pet.asleep_until) || @user_pet.energy < cost
 
   %div#interactions.mt-6.flex.justify-center.space-x-4

--- a/app/views/user_pets/energy_tick.turbo_stream.haml
+++ b/app/views/user_pets/energy_tick.turbo_stream.haml
@@ -1,0 +1,3 @@
+-# app/views/user_pets/energy_tick.turbo_stream.haml
+= turbo_stream.update "pet_energy_#{@user_pet.id}" do
+  = render "pets/energy_display", user_pet: @user_pet

--- a/config/initializers/game_config.rb
+++ b/config/initializers/game_config.rb
@@ -2,4 +2,7 @@ module GameConfig
   BASE_TICK_INTERVAL = 1.seconds
   BASE_ENERGY_VALUE = 1       # energy gained per tick before multipliers
 
+  # Interval at which pets regain 1 energy point
+  PET_ENERGY_INTERVAL = 5.minutes
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
       post :equip
       post :interact
       post :level_up
-      post :interact_preview 
+      post :interact_preview
+      post :energy_tick
     end
     collection do
       post :unequip


### PR DESCRIPTION
## Summary
- show "Energy is at Max" instead of a countdown when energy is full
- restart the regen timer when energy is spent from full

## Testing
- ❌ `bundle exec rake test` *(failed: Ruby 3.3.0 isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68404b079718832abc69a1a58810ff5d